### PR TITLE
feat(user-metadata): support updating year_of_birth

### DIFF
--- a/solve_ninja/api/common.py
+++ b/solve_ninja/api/common.py
@@ -871,6 +871,7 @@ def update_user_metadata(user, user_data):
     if frappe.db.exists("User Metadata", user):
         user_metadata = frappe.get_doc("User Metadata", user)
         user_metadata.pincode = user_data.get("pincode")
+        user_metadata.year_of_birth = user_data.get("year_of_birth")
         if user_data.get("org_id") and frappe.db.exists("User Organization", user_data.get("org_id")):
             user_metadata.org_id = user_data.get("org_id")
         user_metadata.save(ignore_permissions=True)


### PR DESCRIPTION
Added  field handling in update_user_metadata to ensure the value is saved along with other user details like pincode and org_id.