### PR TITLE
feat: use configurable cmp_base_url for user profile links

### DIFF
--- a/solve_ninja/api/leaderboard.py
+++ b/solve_ninja/api/leaderboard.py
@@ -308,6 +308,11 @@ def search_users_(filters=None, raw=False, page_length=10, start=0):
 		for count, data in enumerate(users, start + 1):
 			data["recent_rank"] = count
 
+	for row in users:
+		if frappe.conf.get("cmp_base_url"):
+			row.user_profile = f"{frappe.conf.get('cmp_base_url')}/user-profile/{row.username}"
+		else:
+			row.user_profile = frappe.utils.get_url(f"/user-profile/{row.username}")
 	# Apply `hr_range` Filter in Python (If Needed)
 	# if filters.get("hr_range"):
 	# 	users = filter_by_hour_range(users, filters["hr_range"])

--- a/solve_ninja/api/user.py
+++ b/solve_ninja/api/user.py
@@ -98,7 +98,10 @@ def get_ninjas(verified=False, page_length=None, start=0):
 	result = query.run(as_dict=True)
 	
 	for row in result:
-		row.user_profile = frappe.utils.get_url(f"/user-profile/{row.username}")
+		if frappe.conf.get("cmp_base_url"):
+			row.user_profile = f"{frappe.conf.get('cmp_base_url')}/user-profile/{row.username}"
+		else:
+			row.user_profile = frappe.utils.get_url(f"/user-profile/{row.username}")
 	return result
 
 def get_user_badges(user, badge_type=None):

--- a/solve_ninja/www/leaderboard/index.js
+++ b/solve_ninja/www/leaderboard/index.js
@@ -115,7 +115,7 @@ var get_users = function(filters={}) {
                         <div class="lb_row lb_row_result">
                             <div class="lb_col col_rank">${rank}</div>
                             ${rrh}
-                            <div class="lb_col col_name"><a href="/user-profile/${leader.username}">${leader.full_name}</a></div>
+                            <div class="lb_col col_name"><a href="${leader.user_profile}" target="_blank">${leader.full_name}</a></div>
                             <div class="lb_col col_city">${city}</div>
                             <div class="lb_col col_hours">${leader.hours_invested}</div>
                             <div class="lb_col col_actions">${leader.contribution_count}</div>
@@ -194,7 +194,7 @@ var get_verified_users = function() {
                 $(".vn_content").html("")
                 result.message.forEach(user => {
                     let city = user.city ? `, ${user.city}`: ""
-                    let html = `<div class="vn_box"><a href="${user.user_profile}"`;
+                    let html = `<div class="vn_box"><a href="${user.user_profile}" target="_blank"`;
                     if (user.user_image) {
                         html += `<div class="img_wrapper">
                                     <img src="${ user.user_image}" alt="" />

--- a/solve_ninja/www/templates/ninja.html
+++ b/solve_ninja/www/templates/ninja.html
@@ -1,5 +1,5 @@
 <div class="vn_box">
-    <a href="{{user.user_profile}}">
+    <a href="{{user.user_profile}}" target="_blank">
         {% if user.user_image %}
             <div class="img_wrapper">
                 <img src="{{ frappe.utils.get_url(user.user_image) }}" alt="" />


### PR DESCRIPTION
- Updated `get_ninjas` and `search_users_` to build user_profile URLs using `frappe.conf.cmp_base_url` when available, falling back to `frappe.utils.get_url`.
- Modified leaderboard JS and ninja template to use `user_profile` instead of hardcoded `/user-profile/{username}`.
- Added `target="_blank"` on all profile links to open in a new tab.