### PR TITLE
feat: Replace cache-based OTP storage with Login OTP DocType

### DIFF
--- a/solve_ninja/api/auth.py
+++ b/solve_ninja/api/auth.py
@@ -1,7 +1,5 @@
 import frappe
 import random
-import time
-import json
 from frappe.utils import now_datetime, add_to_date
 from solve_ninja.utils import validate_and_normalize_mobile
 
@@ -54,13 +52,26 @@ def send_otp(mobile):
 		# Generate 6-digit OTP
 		otp = str(random.randint(100000, 999999))
 		
-		# Store OTP in cache with expiry (5 minutes)
-		cache_key = f"login_otp:{mobile}"
-		frappe.cache().set_value(cache_key, {
-			"otp": otp,
+		# Invalidate any existing pending OTPs for this mobile number
+		existing_otps = frappe.get_all("Login OTP", 
+			filters={"mobile": mobile, "status": "Pending"},
+			fields=["name"]
+		)
+		for existing_otp in existing_otps:
+			frappe.db.set_value("Login OTP", existing_otp.name, "status", "Expired")
+		
+		# Store OTP in DocType with expiry (5 minutes)
+		valid_till = add_to_date(now_datetime(), minutes=5)
+		login_otp = frappe.get_doc({
+			"doctype": "Login OTP",
+			"mobile": mobile,
 			"user": user.name,
-			"timestamp": time.time()
-		}, expires_in_sec=300)  # 5 minutes
+			"otp": otp,
+			"valid_till": valid_till,
+			"status": "Pending"
+		})
+		login_otp.insert(ignore_permissions=True)
+		frappe.db.commit()
 		
 		# Send OTP via WhatsApp using Glific HSM template
 		whatsapp_sent = send_hsm_otp(mobile, otp)
@@ -130,25 +141,46 @@ def verify_otp_login(mobile, otp, redirect_to=None):
 				"message": "No account found with this mobile number"
 			}
 		
-		# Get OTP from cache using the normalized mobile number
-		cache_key = f"login_otp:{mobile}"
-		otp_data = frappe.cache().get_value(cache_key)
+		# Get OTP from DocType using the normalized mobile number
+		login_otp = frappe.get_all("Login OTP",
+			filters={
+				"mobile": mobile,
+				"status": "Pending",
+				"user": user.name
+			},
+			fields=["name", "valid_till"],
+			order_by="creation desc",
+			limit=1
+		)
 		
-		if not otp_data:
+		if not login_otp:
+			return {
+				"success": False,
+				"message": "OTP not found. Please request a new one."
+			}
+		
+		login_otp = login_otp[0]
+		otp_doc = frappe.get_doc("Login OTP", login_otp.name)
+		
+		# Check if OTP has expired
+		if now_datetime() > otp_doc.valid_till:
+			frappe.db.set_value("Login OTP", login_otp.name, "status", "Expired")
+			frappe.db.commit()
 			return {
 				"success": False,
 				"message": "OTP has expired. Please request a new one."
 			}
 		
-		# Verify OTP
-		if otp_data.get("otp") != otp:
+		# Verify OTP (get decrypted password from password field)
+		decrypted_otp = otp_doc.get_password("otp")
+		if decrypted_otp != otp:
 			return {
 				"success": False,
 				"message": "Invalid OTP. Please try again."
 			}
 		
 		# Get user details
-		user_name = otp_data.get("user")
+		user_name = otp_doc.user
 		user = frappe.get_doc("User", user_name)
 		
 		if not user.enabled:
@@ -157,8 +189,9 @@ def verify_otp_login(mobile, otp, redirect_to=None):
 				"message": "Your account is disabled. Please contact administrator."
 			}
 		
-		# Clear OTP from cache
-		frappe.cache().delete_value(cache_key)
+		# Mark OTP as Used
+		frappe.db.set_value("Login OTP", login_otp.name, "status", "Used")
+		frappe.db.commit()
 		
 		# Login the user
 		frappe.local.login_manager.user = user_name
@@ -241,7 +274,6 @@ def send_hsm_otp(mobile, otp):
 			# Store wa_id in ninja profile for future use
 			ninja_profile.db_set("wa_id", contact_id, commit=True)
 			ninja_profile.reload()
-		print(response)
 	else:
 		# Use existing wa_id
 		contact_id = ninja_profile.wa_id

--- a/solve_ninja/solve_ninja/doctype/login_otp/login_otp.json
+++ b/solve_ninja/solve_ninja/doctype/login_otp/login_otp.json
@@ -1,0 +1,84 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-11-30 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "mobile",
+  "user",
+  "column_break_1",
+  "otp",
+  "valid_till",
+  "status"
+ ],
+ "fields": [
+  {
+   "fieldname": "mobile",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Mobile",
+   "reqd": 1
+  },
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "User",
+   "options": "User",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_1",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "otp",
+   "fieldtype": "Password",
+   "label": "OTP",
+   "reqd": 1
+  },
+  {
+   "fieldname": "valid_till",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "Valid Till",
+   "reqd": 1
+  },
+  {
+   "default": "Pending",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "options": "Pending\nUsed\nExpired",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-01-27 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Solve Ninja",
+ "name": "Login OTP",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}
+

--- a/solve_ninja/solve_ninja/doctype/login_otp/login_otp.py
+++ b/solve_ninja/solve_ninja/doctype/login_otp/login_otp.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2025, Solve Ninja and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+
+class LoginOTP(Document):
+	pass
+


### PR DESCRIPTION
- Create Login OTP DocType with fields: mobile, user, otp (password), valid_till, status
- Update send_otp() to store OTPs in DocType instead of cache
- Update verify_otp_login() to validate against DocType records
- Add automatic expiration and status tracking (Pending/Used/Expired)
- Invalidate existing pending OTPs when new OTP is requested
- Remove unused imports (time, json)
- Remove debug print statement